### PR TITLE
removed error if not configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Modify/create your plugins.json file to include the plugin:
 {
   "server": [
     // ...
-    {"@coralproject/talk-plugin-prom": "^0.0.10-alpha"},
+    {"@coralproject/talk-plugin-prom": "^0.0.11-alpha"},
     // ...
   ],
   "client": [

--- a/index.js
+++ b/index.js
@@ -21,9 +21,7 @@ if (
   !config.PUSH_GATEWAY_URL &&
   !config.METRICS_MOUNT_PATH
 ) {
-  throw new Error(
-    'must specify at least one of PROM_METRICS_MOUNT_PATH PROM_PUSH_GATEWAY_URL'
-  );
+  console.error('talk-plugin-prom is not properly configured, no metrics will be pushed')
 }
 
 function configurePushgateway() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk-plugin-prom",
-  "version": "0.0.10-alpha",
+  "version": "0.0.11-alpha",
   "main": "index.js",
   "author": "Wyatt Johnson <wyattjoh@gmail.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Changes the plugin behavior to log an error instead of throwing one if the plugin config vars are not set. 

The push gateway is still only activated and triggered if configs are provided, but this should allow the configs to be ignored in a "staging" or other dev env. 